### PR TITLE
chore(studio): move OpenClaw bootstrap into init container

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=builder /build/node_modules ./node_modules
 
 RUN ln -sf /app/node_modules/openclaw/openclaw.mjs /usr/local/bin/openclaw \
     && ln -sf /app/node_modules/@kweaver-ai/kweaver-sdk/bin/kweaver.js /usr/local/bin/kweaver \
-    && chmod +x /app/scripts/docker-entrypoint.sh
+    && chmod +x /app/scripts/docker-entrypoint.sh /app/scripts/openclaw-init.sh
 
 EXPOSE 3000
 

--- a/studio/README.md
+++ b/studio/README.md
@@ -139,6 +139,13 @@ docker run \
 
 注意：在完成 OpenClaw 初始化之前请不要使用 `--restart unless-stopped` 参数.
 
+在 Kubernetes / Helm 部署中，镜像启动前会先执行 `init-container`：
+
+- 安装/刷新 `dip` OpenClaw 插件
+- 执行 `node /app/scripts/init_agents/index.mjs`，同步内置 Agent 工作区与相关配置
+
+主容器只负责启动 Studio 服务与 OpenClaw Gateway 守护进程。
+
 4. 复制 `container_id`
 
 5. 进入容器

--- a/studio/chart/templates/deployment.yaml
+++ b/studio/chart/templates/deployment.yaml
@@ -26,6 +26,24 @@ spec:
           hostPath:
             path: {{ .Values.studio.envFileHostPath }}
             type: FileOrCreate
+      initContainers:
+        - name: openclaw-init
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/app/scripts/openclaw-init.sh"]
+          env:
+            - name: USE_EXTERNAL_OPENCLAW
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Chart.Name }}-config
+                  key: USE_EXTERNAL_OPENCLAW
+          resources:
+            {{- toYaml .Values.resources.init | nindent 12 }}
+          volumeMounts:
+            - name: openclaw-host-path
+              mountPath: /root/.openclaw
+            - name: env-file-host-path
+              mountPath: /app/.env
       containers:
         - name: dip-studio
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/studio/chart/values.yaml
+++ b/studio/chart/values.yaml
@@ -48,6 +48,13 @@ studio:
   useExternalOpenClaw: false
 
 resources:
+  init:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 4
+      memory: 4Gi
   studio:
     requests:
       cpu: 100m

--- a/studio/scripts/docker-entrypoint.sh
+++ b/studio/scripts/docker-entrypoint.sh
@@ -42,49 +42,6 @@ fi
 node dist/server.js &
 SERVER_PID=$!
 
-resolve_installed_dip_plugin_dir() {
-  PLUGIN_INFO_OUTPUT="$(openclaw plugins info dip --json 2>&1 || true)"
-
-  printf '%s' "$PLUGIN_INFO_OUTPUT" \
-    | node -e '
-        let input = "";
-        process.stdin.on("data", chunk => (input += chunk));
-        process.stdin.on("end", () => {
-          const start = input.indexOf("{");
-          if (start < 0) {
-            process.exit(1);
-          }
-
-          let payload;
-          try {
-            payload = JSON.parse(input.slice(start));
-          } catch {
-            process.exit(1);
-          }
-
-          if (typeof payload.source !== "string" || payload.source.length === 0) {
-            process.exit(1);
-          }
-
-          process.stdout.write(require("node:path").dirname(payload.source));
-        });
-      '
-}
-
-install_dip_plugin() {
-  if PLUGIN_INSTALL_DIR="$(resolve_installed_dip_plugin_dir)"; then
-    echo "dip plugin already installed, replacing existing installation"
-    if [ -n "$PLUGIN_INSTALL_DIR" ]; then
-      rm -rf "$PLUGIN_INSTALL_DIR"
-    fi
-  fi
-
-  echo "installing dip plugin from /app/extensions/dip"
-  openclaw plugins install /app/extensions/dip
-}
-
-install_dip_plugin
-
 while :; do
   openclaw gateway --allow-unconfigured &
   GATEWAY_PID=$!

--- a/studio/scripts/init_agents/index.mjs
+++ b/studio/scripts/init_agents/index.mjs
@@ -158,6 +158,16 @@ function upsertAgentConfig(agentConfigs, newAgent) {
   console.log(`[新增] 在配置文件中注册 ${newAgent.id}`);
 }
 
+function ensureArchiveToolAllowed(cfg) {
+  const tools = cfg.tools && typeof cfg.tools === "object" ? cfg.tools : {};
+  const alsoAllow = Array.isArray(tools.alsoAllow) ? tools.alsoAllow : [];
+
+  cfg.tools = {
+    ...tools,
+    alsoAllow: alsoAllow.includes("archive") ? alsoAllow : [...alsoAllow, "archive"]
+  };
+}
+
 async function initOpenClawConfig(builtInAgents) {
   console.log("🛠️ 开始校准 openclaw.json 中的 Agent 配置...");
   const configPath = path.join(STATE_DIR, "openclaw.json");
@@ -180,6 +190,7 @@ async function initOpenClawConfig(builtInAgents) {
     ...(cfg.cron || {}),
     sessionRetention: false
   };
+  ensureArchiveToolAllowed(cfg);
 
   for (const agent of builtInAgents) {
     upsertAgentConfig(cfg.agents.list, {

--- a/studio/scripts/openclaw-init.sh
+++ b/studio/scripts/openclaw-init.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -eu
+
+resolve_installed_dip_plugin_dir() {
+  PLUGIN_INFO_OUTPUT="$(openclaw plugins info dip --json 2>&1 || true)"
+
+  printf '%s' "$PLUGIN_INFO_OUTPUT" \
+    | node -e '
+        let input = "";
+        process.stdin.on("data", chunk => (input += chunk));
+        process.stdin.on("end", () => {
+          const start = input.indexOf("{");
+          if (start < 0) {
+            process.exit(1);
+          }
+
+          let payload;
+          try {
+            payload = JSON.parse(input.slice(start));
+          } catch {
+            process.exit(1);
+          }
+
+          if (typeof payload.source !== "string" || payload.source.length === 0) {
+            process.exit(1);
+          }
+
+          process.stdout.write(require("node:path").dirname(payload.source));
+        });
+      '
+}
+
+install_dip_plugin() {
+  if PLUGIN_INSTALL_DIR="$(resolve_installed_dip_plugin_dir)"; then
+    echo "dip plugin already installed, replacing existing installation"
+    if [ -n "$PLUGIN_INSTALL_DIR" ]; then
+      rm -rf "$PLUGIN_INSTALL_DIR"
+    fi
+  fi
+
+  echo "installing dip plugin from /app/extensions/dip"
+  openclaw plugins install /app/extensions/dip
+}
+
+install_dip_plugin
+node /app/scripts/init_agents/index.mjs


### PR DESCRIPTION
## 变更说明
- 新增 `studio/scripts/openclaw-init.sh`，并通过 Helm `initContainer` 执行
- 将 OpenClaw 插件安装逻辑从主容器入口脚本移出
- 保留 `init:agents` 作为幂等配置同步入口，并确保 `tools.alsoAllow` 包含 `archive`
- 更新 `studio/README.md`，说明新的容器启动流程

## 验证
- `sh -n studio/scripts/openclaw-init.sh`
- `sh -n studio/scripts/docker-entrypoint.sh`
- `helm template dip-studio ./studio/chart`
- `node --check studio/scripts/init_agents/index.mjs`
