### PR TITLE
fix(studio): 修复 HTML 归档物预览，支持init-container的容错

### DIFF
--- a/studio/README.md
+++ b/studio/README.md
@@ -141,7 +141,8 @@ docker run \
 
 在 Kubernetes / Helm 部署中，镜像启动前会先执行 `init-container`：
 
-- 安装/刷新 `dip` OpenClaw 插件
+- 若挂载目录中不存在 `openclaw.json` 或该文件为空，会先创建一个最小 `{}` 配置
+- 安装/刷新 `dip` OpenClaw 插件；若 OpenClaw CLI 仍执行失败，会继续执行后续初始化流程
 - 执行 `node /app/scripts/init_agents/index.mjs`，同步内置 Agent 工作区与相关配置
 
 主容器只负责启动 Studio 服务与 OpenClaw Gateway 守护进程。

--- a/studio/README.md
+++ b/studio/README.md
@@ -988,6 +988,6 @@ If any file cannot be read, explicitly report which path failed and why.
 | key | string | 是 | 会话 key |
 | subpath | string | 是 | 归档子路径，支持多级目录 |
 
-响应：`200 application/json | application/octet-stream | text/plain`
+响应：`200 application/json | application/octet-stream | text/html | text/plain`
 
 目录返回 JSON，文件返回原始内容。路径解析规则与“获取会话归档列表”一致。

--- a/studio/docs/openapi/public/sessions.paths.yaml
+++ b/studio/docs/openapi/public/sessions.paths.yaml
@@ -258,6 +258,9 @@ paths:
               schema:
                 type: string
                 format: binary
+            text/html:
+              schema:
+                type: string
             text/plain:
               schema:
                 type: string

--- a/studio/scripts/openclaw-init.sh
+++ b/studio/scripts/openclaw-init.sh
@@ -2,6 +2,15 @@
 
 set -eu
 
+ensure_openclaw_config_exists() {
+  CONFIG_PATH="${HOME}/.openclaw/openclaw.json"
+  mkdir -p "$(dirname "$CONFIG_PATH")"
+
+  if [ ! -s "$CONFIG_PATH" ]; then
+    printf '{}\n' > "$CONFIG_PATH"
+  fi
+}
+
 resolve_installed_dip_plugin_dir() {
   PLUGIN_INFO_OUTPUT="$(openclaw plugins info dip --json 2>&1 || true)"
 
@@ -43,5 +52,6 @@ install_dip_plugin() {
   openclaw plugins install /app/extensions/dip
 }
 
-install_dip_plugin
+ensure_openclaw_config_exists
+install_dip_plugin || echo "dip plugin installation failed; continuing init flow"
 node /app/scripts/init_agents/index.mjs

--- a/studio/src/infra/openclaw-archives-http-client.test.ts
+++ b/studio/src/infra/openclaw-archives-http-client.test.ts
@@ -80,6 +80,9 @@ describe("createOpenClawArchivesHeaders", () => {
 
     const withoutToken = createOpenClawArchivesHeaders();
     expect(withoutToken.get("authorization")).toBeNull();
+
+    const fileHeaders = createOpenClawArchivesHeaders(undefined, "*/*");
+    expect(fileHeaders.get("accept")).toBe("*/*");
   });
 });
 
@@ -254,29 +257,37 @@ describe("DefaultOpenClawArchivesHttpClient", () => {
     );
   });
 
-  it("rejects html responses for archive subpaths", async () => {
+  it("reads html archive subpaths as raw file content", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("<!doctype html><html><body>quote</body></html>", {
+        status: 200,
+        headers: {
+          "content-type": "text/html; charset=utf-8"
+        }
+      })
+    );
     const client = new DefaultOpenClawArchivesHttpClient(
       {
         gatewayUrl: "ws://127.0.0.1:19001/ws",
         token: "secret",
         timeoutMs: 5000
       },
-      vi.fn<typeof fetch>().mockResolvedValue(
-        new Response("<!doctype html><html></html>", {
-          status: 200,
-          headers: {
-            "content-type": "text/html; charset=utf-8"
-          }
-        })
-      )
+      fetchImpl
     );
 
-    await expect(
-      client.getSessionArchiveSubpath("de_finance", "session-1", "PLAN.md")
-    ).rejects.toMatchObject({
-      statusCode: 502,
-      message:
-        "OpenClaw /v1/archives returned HTML instead of archives data. The dip plugin archives route may not be loaded."
-    });
+    const result = await client.getSessionArchiveSubpath(
+      "de_finance",
+      "session-1",
+      "quote.html"
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(new TextDecoder().decode(result.body)).toBe(
+      "<!doctype html><html><body>quote</body></html>"
+    );
+    const requestHeaders = fetchImpl.mock.calls[0]?.[1]?.headers as Headers;
+    expect(requestHeaders.get("accept")).toBe("*/*");
+    expect(requestHeaders.get("authorization")).toBe("Bearer secret");
   });
 });

--- a/studio/src/infra/openclaw-archives-http-client.ts
+++ b/studio/src/infra/openclaw-archives-http-client.ts
@@ -163,7 +163,7 @@ implements OpenClawArchivesHttpClient {
       ),
       {
         method: "GET",
-        headers: createOpenClawArchivesHeaders(connectionOptions.token)
+        headers: createOpenClawArchivesHeaders(connectionOptions.token, "*/*")
       }
     ).catch((error: unknown) => {
       throw normalizeOpenClawArchivesError(error);
@@ -172,8 +172,6 @@ implements OpenClawArchivesHttpClient {
     if (!upstreamResponse.ok) {
       throw await createOpenClawArchivesStatusError(upstreamResponse);
     }
-
-    throwIfUnexpectedArchivesContentType(upstreamResponse);
 
     return {
       status: upstreamResponse.status,
@@ -291,11 +289,15 @@ export function encodePathSubpath(subpath: string): string {
  * Creates the headers used to call OpenClaw `/v1/archives`.
  *
  * @param token The optional gateway bearer token.
+ * @param accept The MIME types accepted from OpenClaw.
  * @returns The normalized request headers.
  */
-export function createOpenClawArchivesHeaders(token?: string): Headers {
+export function createOpenClawArchivesHeaders(
+  token?: string,
+  accept = "application/json"
+): Headers {
   const headers = new Headers({
-    accept: "application/json"
+    accept
   });
 
   if (token !== undefined) {

--- a/studio/src/routes/sessions.test.ts
+++ b/studio/src/routes/sessions.test.ts
@@ -1045,9 +1045,9 @@ describe("createSessionsRouter", () => {
     const getSessionArchiveSubpath = vi.fn().mockResolvedValue({
       status: 200,
       headers: new Headers({
-        "content-type": "text/plain"
+        "content-type": "text/html; charset=utf-8"
       }),
-      body: new Uint8Array(Buffer.from("hello"))
+      body: new Uint8Array(Buffer.from("<!doctype html><html></html>"))
     });
     const router = createSessionsRouter(
       {
@@ -1103,9 +1103,14 @@ describe("createSessionsRouter", () => {
       "agent:de_finance:user:user-1:direct:session-1",
       "notes/today.txt"
     );
-    expect(response.setHeader).toHaveBeenCalledWith("content-type", "text/plain");
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "content-type",
+      "text/html; charset=utf-8"
+    );
     expect(response.status).toHaveBeenCalledWith(200);
-    expect(response.send).toHaveBeenCalled();
+    expect(response.send).toHaveBeenCalledWith(
+      Buffer.from("<!doctype html><html></html>")
+    );
     expect(next).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- allow Studio archive subpath proxy to stream HTML archive files instead of treating them as an upstream route-loading failure
- keep archive listing JSON content-type validation unchanged
- document `text/html` archive subpath responses in OpenAPI and README
- include init-container OpenClaw config tolerance already present on this branch

## Tests
- `npm run build`
- `npx vitest run src/infra/openclaw-archives-http-client.test.ts src/routes/sessions.test.ts`
- `npm test`