### PR TITLE
fix(studio): add includeDisabled cron query type

### DIFF
--- a/studio/src/routes/plan.ts
+++ b/studio/src/routes/plan.ts
@@ -26,6 +26,11 @@ import type {
  */
 export interface CronJobListQuery {
   /**
+   * Include disabled jobs when true.
+   */
+  includeDisabled?: string;
+
+  /**
    * Maximum page size.
    */
   limit?: string;


### PR DESCRIPTION
## Summary
- add the missing includeDisabled field to Studio cron job list query typing
- keep existing cron list parsing behavior unchanged

## Tests
- npm run build
- npx vitest run src/routes/plan.test.ts --coverage.enabled=false
- npm test