### PR TITLE
fix(studio): bind default skills on digital human create

### DIFF
--- a/studio/README.md
+++ b/studio/README.md
@@ -816,7 +816,7 @@ DIP 数字员工 Web 界面
 | creature | string | 否 | 数字员工岗位/角色 |
 | icon_id | string | 否 | 图标 ID |
 | soul | string | 否 | `SOUL.md` 内容 |
-| skills | string[] | 否 | 创建时要绑定的技能名称列表；重复值会按首次出现顺序去重。响应中 `skills` 为实际绑定的技能 id 列表 |
+| skills | string[] | 否 | 创建时要追加绑定的技能名称列表；后端会始终先绑定内置技能 `archive-protocol`、`schedule-plan`、`kweaver-core`，再追加该列表；重复值会按首次出现顺序去重。响应中 `skills` 为实际绑定的技能 id 列表 |
 
 响应：`201 application/json`
 

--- a/studio/docs/openapi/public/digital-human.schemas.yaml
+++ b/studio/docs/openapi/public/digital-human.schemas.yaml
@@ -151,7 +151,9 @@ components:
           type: array
           title: 技能目录名列表
           description: |
-            原样作为创建时要绑定的技能列表写入 agent；重复值会按首次出现顺序去重。
+            创建时要绑定的技能列表。后端会始终先绑定 DIP 数字员工内置技能
+            `archive-protocol`、`schedule-plan`、`kweaver-core`，再追加请求中的技能；
+            重复值会按首次出现顺序去重。
           items:
             type: string
         bkn:

--- a/studio/src/logic/digital-human.test.ts
+++ b/studio/src/logic/digital-human.test.ts
@@ -885,9 +885,17 @@ describe("DefaultDigitalHumanLogic lifecycle (filesystem + adapter)", () => {
       })
     );
     expect(updateAgentSkills).toHaveBeenCalledWith(result.id, [
+      "archive-protocol",
+      "schedule-plan",
+      "kweaver-core",
       "sk1"
     ]);
-    expect(result.skills).toEqual(["sk1"]);
+    expect(result.skills).toEqual([
+      "archive-protocol",
+      "schedule-plan",
+      "kweaver-core",
+      "sk1"
+    ]);
   });
 
   it("createDigitalHuman uses the provided id instead of generating a uuid", async () => {
@@ -932,7 +940,7 @@ describe("DefaultDigitalHumanLogic lifecycle (filesystem + adapter)", () => {
     expect(result.id).toBe("__bkn_creator__");
   });
 
-  it("createDigitalHuman leaves skills empty when request omits skills", async () => {
+  it("createDigitalHuman binds default built-in skills when request omits skills", async () => {
     vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
       "dddddddd-dddd-dddd-dddd-dddddddddddd"
     );
@@ -959,8 +967,16 @@ describe("DefaultDigitalHumanLogic lifecycle (filesystem + adapter)", () => {
 
     const result = await logic.createDigitalHuman({ name: "NoSkills" });
 
-    expect(updateAgentSkills).toHaveBeenCalledWith(result.id, []);
-    expect(result.skills).toEqual([]);
+    expect(updateAgentSkills).toHaveBeenCalledWith(result.id, [
+      "archive-protocol",
+      "schedule-plan",
+      "kweaver-core"
+    ]);
+    expect(result.skills).toEqual([
+      "archive-protocol",
+      "schedule-plan",
+      "kweaver-core"
+    ]);
   });
 
   it("createDigitalHuman deduplicates repeated request skill names", async () => {
@@ -990,10 +1006,17 @@ describe("DefaultDigitalHumanLogic lifecycle (filesystem + adapter)", () => {
     });
 
     expect(updateAgentSkills).toHaveBeenCalledWith(result.id, [
+      "archive-protocol",
+      "schedule-plan",
+      "kweaver-core",
       "other",
-      "archive-protocol"
     ]);
-    expect(result.skills).toEqual(["other", "archive-protocol"]);
+    expect(result.skills).toEqual([
+      "archive-protocol",
+      "schedule-plan",
+      "kweaver-core",
+      "other"
+    ]);
   });
 
   it("getDigitalHuman returns the full bound skill list in the response", async () => {

--- a/studio/src/types/digital-human.ts
+++ b/studio/src/types/digital-human.ts
@@ -242,8 +242,9 @@ export interface CreateDigitalHumanRequest {
   soul?: string;
 
   /**
-   * Skill names to bind to the agent at create time.
-   * Duplicates are ignored while preserving first occurrence order.
+   * Extra skill names to bind to the agent at create time.
+   * Built-in digital-human skills are prepended by the service, then duplicates are
+   * ignored while preserving first occurrence order.
    */
   skills?: string[];
 

--- a/studio/src/utils/skills.test.ts
+++ b/studio/src/utils/skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_DIGITAL_HUMAN_SKILLS,
   deriveSkillIdFromUploadedFilename,
   isDefaultDigitalHumanSkillSlug,
   isValidSkillSlug,
@@ -49,12 +50,22 @@ describe("utils/skills digital-human defaults", () => {
     expect(isDefaultDigitalHumanSkillSlug("custom")).toBe(false);
   });
 
-  it("normalizeCreateDigitalHumanSkills dedupes request values only", () => {
-    expect(normalizeCreateDigitalHumanSkills()).toEqual([]);
-    expect(normalizeCreateDigitalHumanSkills(["x"])).toEqual(["x"]);
+  it("normalizeCreateDigitalHumanSkills includes built-in defaults first", () => {
+    expect(normalizeCreateDigitalHumanSkills()).toEqual(DEFAULT_DIGITAL_HUMAN_SKILLS);
+    expect(normalizeCreateDigitalHumanSkills(["x"])).toEqual([
+      ...DEFAULT_DIGITAL_HUMAN_SKILLS,
+      "x",
+    ]);
     expect(normalizeCreateDigitalHumanSkills(["x", "x", "y"])).toEqual([
+      ...DEFAULT_DIGITAL_HUMAN_SKILLS,
       "x",
       "y"
     ]);
+  });
+
+  it("normalizeCreateDigitalHumanSkills dedupes defaults repeated in request", () => {
+    expect(
+      normalizeCreateDigitalHumanSkills(["archive-protocol", "x", "schedule-plan"])
+    ).toEqual([...DEFAULT_DIGITAL_HUMAN_SKILLS, "x"]);
   });
 });

--- a/studio/src/utils/skills.ts
+++ b/studio/src/utils/skills.ts
@@ -37,7 +37,8 @@ export function isDefaultDigitalHumanSkillSlug(slug: string): boolean {
 }
 
 /**
- * Deduplicates optional request skill ids while preserving first occurrence order.
+ * Prepends default digital-human skills, then deduplicates optional request skill ids while
+ * preserving first occurrence order.
  *
  * @param requestSkills Optional skill names from the create request.
  * @returns The normalized skill list to persist on the agent.
@@ -47,7 +48,7 @@ export function normalizeCreateDigitalHumanSkills(
 ): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
-  for (const s of requestSkills ?? []) {
+  for (const s of [...DEFAULT_DIGITAL_HUMAN_SKILLS, ...(requestSkills ?? [])]) {
     if (!seen.has(s)) {
       seen.add(s);
       out.push(s);


### PR DESCRIPTION
# Pull Request: fix(studio): bind default skills on digital human create

## 目的

修复 #114：在 DIP Studio 创建数字员工时，如果用户只输入名称后直接发布，前端不会传入技能配置；后端原先会把缺失的 `skills` 归一化为空数组并写入绑定，导致默认 3 个内置技能没有绑定。

## 实现细节

- 调整 `normalizeCreateDigitalHumanSkills`：创建数字员工时始终先加入 `archive-protocol`、`schedule-plan`、`kweaver-core`，再追加请求中的技能。
- 保持按首次出现顺序去重，避免请求中重复传入默认技能或自定义技能时产生重复绑定。
- 更新 `CreateDigitalHumanRequest.skills` 的类型注释，明确该字段表示额外追加技能。
- 同步更新 `docs/openapi/public/digital-human.schemas.yaml` 与 `README.md` 中创建数字员工接口的 `skills` 语义说明。
- 更新回归测试，覆盖未传 `skills`、传入自定义技能、重复传入默认技能的创建流程。

## 测试证据

### 自动化测试

- [x] 单元测试：`npm test`（36 个测试文件，535 个测试通过，行覆盖率 92.03%）
- [ ] 集成测试
- [ ] E2E 测试
- [x] 其他：`npm run build`

### 手工测试

未运行（原因：该问题的核心行为已由 `src/utils/skills.test.ts` 和 `src/logic/digital-human.test.ts` 覆盖；本次未启动实际 OpenClaw/Gateway 环境做端到端验证）。

## 影响评估

- API 行为：`POST /api/dip-studio/v1/digital-human` 创建时的技能绑定结果改变；即使请求不传 `skills`，也会绑定 3 个 DIP 内置技能。
- 文档：已同步更新 OpenAPI schema 与 README API 说明。
- 类型：已同步更新 `src/types/digital-human.ts` 中 `CreateDigitalHumanRequest.skills` 的语义注释。
- 兼容性：请求中已有自定义技能时会保留并追加在默认技能之后；重复技能会去重。
- 设计文档：未修改 `docs/design`。

## Review Checklist

- [ ] 代码符合项目风格
- [ ] 函数和参数在适用处包含 TSDoc/JSDoc
- [ ] 行为变更已新增或更新测试
- [ ] 自动化测试已本地通过，或已说明未运行原因
- [ ] routes 变更已同步更新 `docs/openapi` 和 `README.md` API 部分
- [ ] 类型变更已同步更新 `src/types`
- [ ] 未包含无关文件、格式噪音或推测性抽象
- [ ] 未修改 `docs/design`

## 关联问题

Closes #114