### PR TITLE
[codex] fix preset digital human list

### DIFF
--- a/web/apps/dip/src/apis/dip-studio/digital-human/index.d.ts
+++ b/web/apps/dip/src/apis/dip-studio/digital-human/index.d.ts
@@ -50,6 +50,8 @@ export interface BuiltInDigitalHuman {
   description?: string
   /** 头像：可为 data URL、预置 dh_1…dh_8、或裸 base64 */
   icon_id?: string
+  /** 当前是否已存在同 ID 的数字员工 */
+  created?: boolean
 }
 
 export type BuiltInDigitalHumanList = BuiltInDigitalHuman[]

--- a/web/apps/dip/src/pages/InitialConfiguration/components/SelectPresetDigitalHumanStep.tsx
+++ b/web/apps/dip/src/pages/InitialConfiguration/components/SelectPresetDigitalHumanStep.tsx
@@ -1,5 +1,5 @@
 import { Button, Checkbox, message, Spin } from 'antd'
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 import intl from 'react-intl-universal'
 import {
   type BuiltInDigitalHuman,
@@ -19,10 +19,10 @@ const SelectPresetDigitalHumanStep = ({
   onSkip,
   onConfirmSuccess,
 }: SelectPresetDigitalHumanStepProps) => {
-  const [selected, setSelected] = useState(true)
   const [listLoading, setListLoading] = useState(true)
   const [listError, setListError] = useState<string | null>(null)
   const [templates, setTemplates] = useState<BuiltInDigitalHuman[]>([])
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [creating, setCreating] = useState(false)
 
   useEffect(() => {
@@ -33,10 +33,13 @@ const SelectPresetDigitalHumanStep = ({
       try {
         const data = await getBuiltInDigitalHumanList()
         if (cancelled) return
-        setTemplates(Array.isArray(data) ? data : [])
+        const nextTemplates = Array.isArray(data) ? data : []
+        setTemplates(nextTemplates)
+        setSelectedIds(nextTemplates.filter((item) => !item.created).map((item) => item.id))
       } catch (error: any) {
         if (cancelled) return
         setTemplates([])
+        setSelectedIds([])
         setListError(
           error?.description || intl.get('initialConfiguration.selectPreset.listLoadFailed'),
         )
@@ -50,20 +53,28 @@ const SelectPresetDigitalHumanStep = ({
     }
   }, [])
 
-  const first = templates[0]
-  const avatarSrc = useMemo(
-    () => resolveDigitalHumanIconSrc(first?.icon_id, defaultDigitalHumanAvatar),
-    [first?.icon_id],
-  )
-
-  const canSubmit = selected && Boolean(first) && !listLoading && listError === null
+  const installableTemplates = templates.filter((item) => !item.created)
+  const canSubmit =
+    selectedIds.length > 0 &&
+    installableTemplates.length > 0 &&
+    !listLoading &&
+    listError === null
   const primaryDisabled = !canSubmit
 
+  const toggleSelected = (id: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      if (checked) {
+        return prev.includes(id) ? prev : [...prev, id]
+      }
+      return prev.filter((item) => item !== id)
+    })
+  }
+
   const handleConfirm = async () => {
-    if (!first || primaryDisabled) return
+    if (primaryDisabled) return
     setCreating(true)
     try {
-      await createBuiltInDigitalHuman(first.id)
+      await createBuiltInDigitalHuman(selectedIds.join(','))
       onConfirmSuccess()
     } catch (e: unknown) {
       const desc = e && typeof e === 'object' && 'description' in e ? String(e.description) : ''
@@ -93,28 +104,51 @@ const SelectPresetDigitalHumanStep = ({
             desc={listError}
             type="failed"
           />
-        ) : !first ? (
+        ) : templates.length === 0 ? (
           <Empty title={intl.get('initialConfiguration.selectPreset.emptyTitle')} />
         ) : (
-          <div className="self-center">
-            <button
-              type="button"
-              className="flex flex-col items-center justify-center mt-4 w-[264px] bg-black/[0.02] rounded-md px-5 py-4 text-left relative hover:bg-black/[0.03] transition-colors"
-              onClick={() => setSelected((v) => !v)}
-            >
-              <div className="absolute top-3 right-3">
-                <Checkbox checked={selected} onChange={(e) => setSelected(e.target.checked)} />
-              </div>
+          <div className="self-center flex flex-wrap justify-center gap-4">
+            {templates.map((template) => {
+              const checked = selectedIds.includes(template.id)
+              const avatarSrc = resolveDigitalHumanIconSrc(
+                template.icon_id,
+                defaultDigitalHumanAvatar,
+              )
 
-              <div className="w-[64px] h-[64px] rounded-full overflow-hidden flex items-center justify-center">
-                <img src={avatarSrc} alt={first.name} className="w-full h-full object-cover" />
-              </div>
+              return (
+                <button
+                  key={template.id}
+                  type="button"
+                  className="flex flex-col items-center justify-center mt-4 w-[264px] bg-black/[0.02] rounded-md px-5 py-4 text-left relative hover:bg-black/[0.03] transition-colors disabled:cursor-not-allowed disabled:hover:bg-black/[0.02]"
+                  onClick={() => !template.created && toggleSelected(template.id, !checked)}
+                  disabled={template.created}
+                >
+                  <div className="absolute top-3 right-3">
+                    {template.created ? (
+                      <span className="text-xs text-black/45">
+                        {intl.get('initialConfiguration.selectPreset.installed')}
+                      </span>
+                    ) : (
+                      <Checkbox
+                        checked={checked}
+                        onChange={(e) => toggleSelected(template.id, e.target.checked)}
+                      />
+                    )}
+                  </div>
 
-              <div className="text-base font-medium text-[--dip-text-color] mt-1">{first.name}</div>
-              <div className="mt-2 text-black/65 leading-6 text-center">
-                {first.description?.trim()}
-              </div>
-            </button>
+                  <div className="w-[64px] h-[64px] rounded-full overflow-hidden flex items-center justify-center">
+                    <img src={avatarSrc} alt={template.name} className="w-full h-full object-cover" />
+                  </div>
+
+                  <div className="text-base font-medium text-[--dip-text-color] mt-1">
+                    {template.name}
+                  </div>
+                  <div className="mt-2 text-black/65 leading-6 text-center">
+                    {template.description?.trim()}
+                  </div>
+                </button>
+              )
+            })}
           </div>
         )}
       </div>

--- a/web/apps/dip/src/pages/InitialConfiguration/components/SystemSettingsModal/SystemPresetResourcePanel.tsx
+++ b/web/apps/dip/src/pages/InitialConfiguration/components/SystemSettingsModal/SystemPresetResourcePanel.tsx
@@ -1,11 +1,10 @@
 import { Button, message, Spin } from 'antd'
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 import intl from 'react-intl-universal'
 import {
   type BuiltInDigitalHuman,
   createBuiltInDigitalHuman,
   getBuiltInDigitalHumanList,
-  getDigitalHumanList,
 } from '@/apis/dip-studio/digital-human'
 import defaultDigitalHumanAvatar from '@/assets/images/bkn-creator.png'
 import Empty from '@/components/Empty'
@@ -19,8 +18,7 @@ const SystemPresetResourcePanel = ({ onConfirmSuccess }: SystemPresetResourcePan
   const [listLoading, setListLoading] = useState(true)
   const [listError, setListError] = useState<string | null>(null)
   const [templates, setTemplates] = useState<BuiltInDigitalHuman[]>([])
-  const [presetExists, setPresetExists] = useState(false)
-  const [creating, setCreating] = useState(false)
+  const [creatingIds, setCreatingIds] = useState<string[]>([])
 
   useEffect(() => {
     let cancelled = false
@@ -28,30 +26,13 @@ const SystemPresetResourcePanel = ({ onConfirmSuccess }: SystemPresetResourcePan
       setListLoading(true)
       setListError(null)
       try {
-        const [builtInList, digitalHumanList] = await Promise.all([
-          getBuiltInDigitalHumanList(),
-          getDigitalHumanList(),
-        ])
+        const builtInList = await getBuiltInDigitalHumanList()
         if (cancelled) return
         const nextTemplates = Array.isArray(builtInList) ? builtInList : []
         setTemplates(nextTemplates)
-
-        const firstTemplate = nextTemplates[0]
-        if (!firstTemplate) {
-          setPresetExists(false)
-          return
-        }
-
-        const exists = Array.isArray(digitalHumanList)
-          ? digitalHumanList.some(
-              (item) => item.id === firstTemplate.id || item.name === firstTemplate.name,
-            )
-          : false
-        setPresetExists(exists)
       } catch (error: any) {
         if (cancelled) return
         setTemplates([])
-        setPresetExists(false)
         setListError(
           error?.description || intl.get('initialConfiguration.selectPreset.listLoadFailed'),
         )
@@ -65,27 +46,21 @@ const SystemPresetResourcePanel = ({ onConfirmSuccess }: SystemPresetResourcePan
     }
   }, [])
 
-  const first = templates[0]
-  const avatarSrc = useMemo(
-    () => resolveDigitalHumanIconSrc(first?.icon_id, defaultDigitalHumanAvatar),
-    [first?.icon_id],
-  )
-
-  const handleConfirm = async () => {
-    if (!first || listLoading || listError) return
-    if (presetExists) {
+  const handleConfirm = async (template: BuiltInDigitalHuman) => {
+    if (listLoading || listError) return
+    if (template.created) {
       onConfirmSuccess()
       return
     }
-    setCreating(true)
+    setCreatingIds((prev) => [...prev, template.id])
     try {
-      await createBuiltInDigitalHuman(first.id)
+      await createBuiltInDigitalHuman(template.id)
       onConfirmSuccess()
     } catch (e: unknown) {
       const desc = e && typeof e === 'object' && 'description' in e ? String(e.description) : ''
       message.error(desc || intl.get('initialConfiguration.selectPreset.createFailed'))
     } finally {
-      setCreating(false)
+      setCreatingIds((prev) => prev.filter((id) => id !== template.id))
     }
   }
 
@@ -109,27 +84,48 @@ const SystemPresetResourcePanel = ({ onConfirmSuccess }: SystemPresetResourcePan
             desc={listError}
             type="failed"
           />
-        ) : !first ? (
+        ) : templates.length === 0 ? (
           <Empty title={intl.get('initialConfiguration.selectPreset.emptyTitle')} />
         ) : (
-          <div className="flex flex-col items-center justify-center w-[264px] bg-black/[0.03] rounded-md px-5 py-5 text-left">
-            <div className="w-[64px] h-[64px] rounded-full overflow-hidden flex items-center justify-center">
-              <img src={avatarSrc} alt={first.name} className="w-full h-full object-cover" />
-            </div>
-            <div className="text-base font-medium text-[--dip-text-color] mt-1">{first.name}</div>
-            <div className="mt-2 mb-4 text-black/65 leading-6 text-center">
-              {first.description?.trim()}
-            </div>
-            <Button
-              type="primary"
-              onClick={() => void handleConfirm()}
-              loading={creating}
-              disabled={presetExists}
-            >
-              {presetExists
-                ? intl.get('initialConfiguration.selectPreset.installed')
-                : intl.get('initialConfiguration.selectPreset.installNow')}
-            </Button>
+          <div className="flex flex-wrap gap-4">
+            {templates.map((template) => {
+              const avatarSrc = resolveDigitalHumanIconSrc(
+                template.icon_id,
+                defaultDigitalHumanAvatar,
+              )
+              const creating = creatingIds.includes(template.id)
+
+              return (
+                <div
+                  key={template.id}
+                  className="flex flex-col items-center justify-center w-[264px] bg-black/[0.03] rounded-md px-5 py-5 text-left"
+                >
+                  <div className="w-[64px] h-[64px] rounded-full overflow-hidden flex items-center justify-center">
+                    <img
+                      src={avatarSrc}
+                      alt={template.name}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                  <div className="text-base font-medium text-[--dip-text-color] mt-1">
+                    {template.name}
+                  </div>
+                  <div className="mt-2 mb-4 text-black/65 leading-6 text-center">
+                    {template.description?.trim()}
+                  </div>
+                  <Button
+                    type="primary"
+                    onClick={() => void handleConfirm(template)}
+                    loading={creating}
+                    disabled={template.created}
+                  >
+                    {template.created
+                      ? intl.get('initialConfiguration.selectPreset.installed')
+                      : intl.get('initialConfiguration.selectPreset.installNow')}
+                  </Button>
+                </div>
+              )
+            })}
           </div>
         )}
       </div>

--- a/web/apps/dip/src/pages/InitialConfiguration/components/SystemSettingsModal/__tests__/SystemPresetResourcePanel.test.tsx
+++ b/web/apps/dip/src/pages/InitialConfiguration/components/SystemSettingsModal/__tests__/SystemPresetResourcePanel.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/apis/dip-studio/digital-human', () => ({
+  getBuiltInDigitalHumanList: vi.fn().mockResolvedValue([
+    {
+      id: '__bkn_creator__',
+      name: 'BKN Creator',
+      description: 'built-in creator',
+      created: true,
+    },
+    {
+      id: '__data_analyst__',
+      name: '数据分析员',
+      description: 'built-in analyst',
+      created: false,
+    },
+  ]),
+  getDigitalHumanList: vi.fn().mockResolvedValue([]),
+  createBuiltInDigitalHuman: vi.fn().mockResolvedValue([]),
+}))
+
+import SystemPresetResourcePanel from '../SystemPresetResourcePanel'
+
+describe('SystemPresetResourcePanel', () => {
+  it('renders all built-in digital human templates from the API list', async () => {
+    render(<SystemPresetResourcePanel onConfirmSuccess={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('BKN Creator')).toBeInTheDocument()
+      expect(screen.getByText('数据分析员')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('initialConfiguration.selectPreset.installed')).toBeInTheDocument()
+    expect(screen.getByText('initialConfiguration.selectPreset.installNow')).toBeInTheDocument()
+  })
+})

--- a/web/apps/dip/src/pages/InitialConfiguration/components/__tests__/SelectPresetDigitalHumanStep.test.tsx
+++ b/web/apps/dip/src/pages/InitialConfiguration/components/__tests__/SelectPresetDigitalHumanStep.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/apis/dip-studio/digital-human', () => ({
+  getBuiltInDigitalHumanList: vi.fn().mockResolvedValue([
+    {
+      id: '__bkn_creator__',
+      name: 'BKN Creator',
+      description: 'built-in creator',
+      created: false,
+    },
+    {
+      id: '__data_analyst__',
+      name: '数据分析员',
+      description: 'built-in analyst',
+      created: false,
+    },
+  ]),
+  createBuiltInDigitalHuman: vi.fn().mockResolvedValue([]),
+}))
+
+import SelectPresetDigitalHumanStep from '../SelectPresetDigitalHumanStep'
+
+describe('SelectPresetDigitalHumanStep', () => {
+  it('renders every available built-in template instead of only the first one', async () => {
+    render(<SelectPresetDigitalHumanStep onSkip={vi.fn()} onConfirmSuccess={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('BKN Creator')).toBeInTheDocument()
+      expect(screen.getByText('数据分析员')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- render every built-in digital human template returned by the API in the system settings preset resource panel
- render the full preset template list in the initialization wizard and allow selecting multiple uninstalled templates for installation
- add focused component tests covering multi-item rendering in both entry points

## Root cause
The DIP frontend only consumed `templates[0]` from the built-in digital human list, so the UI never displayed any additional preset templates even when the backend returned multiple items.

## Impact
Users can now see the full preset digital human catalog instead of only the first item. The system settings panel supports per-item installation state, and the initialization wizard no longer hides additional preset templates.

## Validation
- `pnpm vitest run src/pages/InitialConfiguration/components/SystemSettingsModal/__tests__/SystemPresetResourcePanel.test.tsx src/pages/InitialConfiguration/components/__tests__/SelectPresetDigitalHumanStep.test.tsx`
- `pnpm typecheck` *(fails on pre-existing unrelated TypeScript issues in other files)*
